### PR TITLE
Error Whitelisting

### DIFF
--- a/tracing/opentracing/interceptors_test.go
+++ b/tracing/opentracing/interceptors_test.go
@@ -82,7 +82,7 @@ func TestTaggingSuite(t *testing.T) {
 	mockTracer := mocktracer.New()
 	opts := []grpc_opentracing.Option{
 		grpc_opentracing.WithTracer(mockTracer),
-		grpc_opentracing.WithWhitelistedErrorCodes(codes.NotFound),
+		grpc_opentracing.WithIgnoredErrorCodes(codes.NotFound),
 	}
 	s := &OpentracingSuite{
 		mockTracer: mockTracer,

--- a/tracing/opentracing/interceptors_test.go
+++ b/tracing/opentracing/interceptors_test.go
@@ -82,6 +82,7 @@ func TestTaggingSuite(t *testing.T) {
 	mockTracer := mocktracer.New()
 	opts := []grpc_opentracing.Option{
 		grpc_opentracing.WithTracer(mockTracer),
+		grpc_opentracing.WithWhitelistedErrorCodes(codes.NotFound),
 	}
 	s := &OpentracingSuite{
 		mockTracer: mockTracer,
@@ -203,4 +204,14 @@ func (s *OpentracingSuite) TestPingError_PropagatesTraces() {
 	clientSpan, serverSpan := s.assertTracesCreated("/mwitkow.testproto.TestService/PingError")
 	assert.Equal(s.T(), true, clientSpan.Tag("error"), "client span needs to be marked as an error")
 	assert.Equal(s.T(), true, serverSpan.Tag("error"), "server span needs to be marked as an error")
+}
+
+func (s *OpentracingSuite) TestPingError_WhitelistTraces() {
+	ctx := s.createContextFromFakeHttpRequestParent(s.SimpleCtx())
+	erroringPing := &pb_testproto.PingRequest{Value: "something", ErrorCodeReturned: uint32(codes.NotFound)}
+	_, err := s.Client.PingError(ctx, erroringPing)
+	require.Error(s.T(), err, "there must be an error returned here")
+	clientSpan, serverSpan := s.assertTracesCreated("/mwitkow.testproto.TestService/PingError")
+	assert.Nil(s.T(), clientSpan.Tag("error"), "client span must not be marked as an error")
+	assert.Nil(s.T(), serverSpan.Tag("error"), "server span must not be marked as an error")
 }

--- a/tracing/opentracing/options.go
+++ b/tracing/opentracing/options.go
@@ -77,9 +77,9 @@ func shouldMarkWithError(o *options, err error) bool {
 		return true
 	}
 	stat, statusExists := status.FromError(err)
-	var whitelisted bool
+	var ignored bool
 	if statusExists {
-		whitelisted = o.errorCodes[stat.Code()]
+		ignored = o.errorCodes[stat.Code()]
 	}
-	return !whitelisted
+	return !ignored
 }

--- a/tracing/opentracing/options.go
+++ b/tracing/opentracing/options.go
@@ -58,8 +58,8 @@ func WithTracer(tracer opentracing.Tracer) Option {
 	}
 }
 
-// WithWhitelistedErrorCodes sets whitelisted error codes for the middleware.
-func WithWhitelistedErrorCodes(cs ...codes.Code) Option {
+// WithIgnoredErrorCodes sets error codes that will be ignored and not mark the span as errored.
+func WithIgnoredErrorCodes(cs ...codes.Code) Option {
 	return func(o *options) {
 		for _, c := range cs {
 			if o.errorCodes == nil {

--- a/tracing/opentracing/options.go
+++ b/tracing/opentracing/options.go
@@ -6,7 +6,9 @@ package grpc_opentracing
 import (
 	"context"
 
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var (
@@ -24,6 +26,8 @@ type FilterFunc func(ctx context.Context, fullMethodName string) bool
 type options struct {
 	filterOutFunc FilterFunc
 	tracer        opentracing.Tracer
+	// ErrorCodes are a map of grpc error codes. If true, this code will not mark the span as errored.
+	errorCodes map[codes.Code]bool
 }
 
 func evaluateOptions(opts []Option) *options {
@@ -52,4 +56,30 @@ func WithTracer(tracer opentracing.Tracer) Option {
 	return func(o *options) {
 		o.tracer = tracer
 	}
+}
+
+// WithWhitelistedErrorCodes sets whitelisted error codes for the middleware.
+func WithWhitelistedErrorCodes(cs ...codes.Code) Option {
+	return func(o *options) {
+		for _, c := range cs {
+			if o.errorCodes == nil {
+				o.errorCodes = map[codes.Code]bool{}
+			}
+			o.errorCodes[c] = true
+		}
+	}
+}
+
+// shouldMarkWithError reads the options from the list and returns whether the error should mark the span as errored
+// it uses a set of whitelisted grpc error codes for this.
+func shouldMarkWithError(o *options, err error) bool {
+	if o == nil {
+		return true
+	}
+	stat, statusExists := status.FromError(err)
+	var whitelisted bool
+	if statusExists {
+		whitelisted = o.errorCodes[stat.Code()]
+	}
+	return !whitelisted
 }


### PR DESCRIPTION
Add the ability to whitelist errors. This PR will control the logic for marking the span with `error:true` based on GRPC error codes. It uses a set of whitelisted error codes that if found will not mark the span. This works for client and server side rpcs.
